### PR TITLE
Debian 10.3 meilisearch v0.10.0

### DIFF
--- a/deploy-old.sh
+++ b/deploy-old.sh
@@ -1,0 +1,58 @@
+# Install build dependencies
+apt update -y
+apt install git curl gcc make nginx -y
+
+# Download and install Rust toolchain
+curl https://sh.rustup.rs -sSf | sh -s -- -y
+source $HOME/.cargo/env
+
+# Git clone and build MeiliSearch for release on latest tag
+git clone https://github.com/meilisearch/MeiliSearch && cd MeiliSearch
+git checkout v0.8.4
+cargo build --release
+
+# Prepare systemd service for MeiliSearch
+mv target/release/meilisearch /usr/bin/
+cat << EOF >/etc/systemd/system/meilisearch.service
+[Unit]
+Description=MeiliSearch
+After=systend-user-sessions.service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/meilisearch
+
+[Install]
+WantedBy=default.target
+EOF
+
+# Start MeiliSearch service
+systemctl enable meilisearch
+systemctl start meilisearch
+
+# Setup firewalls and Nginx
+ufw allow 'Nginx Full'
+ufw allow 'OpenSSH'
+ufw --force enable
+
+# Set Nginx to proxy MeiliSearch
+cat << EOF > /etc/nginx/sites-enabled/default
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server;
+
+    server_name _;
+
+    location / {
+        proxy_pass  http://127.0.0.1:7700;
+    }
+}
+EOF
+systemctl restart nginx
+
+# Clean up image using DO script
+curl https://raw.githubusercontent.com/digitalocean/marketplace-partners/master/scripts/cleanup.sh | bash
+rm /var/log/auth.log
+rm /var/log/kern.log
+rm /var/log/ufw.log
+curl https://raw.githubusercontent.com/digitalocean/marketplace-partners/master/scripts/img_check.sh | bash

--- a/deploy.sh
+++ b/deploy.sh
@@ -3,7 +3,7 @@ export DEBIAN_FRONTEND=noninteractive
 # Install build dependencies
 echo "deb http://ftp.de.debian.org/debian sid main" >> /etc/apt/sources.list
 apt update -y
-apt install git curl gcc make nginx -y
+apt install git curl ufw gcc make nginx -y
 apt install gcc-10 -y
 
 # Install MeiliSearch v0.10.0
@@ -33,3 +33,21 @@ systemctl start meilisearch
 ufw allow 'Nginx Full'
 ufw allow 'OpenSSH'
 ufw --force enable
+
+# Delete default Nginx config
+rm /etc/nginx/sites-enabled/default
+
+# Set Nginx to proxy MeiliSearch
+cat << EOF > /etc/nginx/sites-enabled/default
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server;
+
+    server_name _;
+
+    location / {
+        proxy_pass  http://127.0.0.1:7700;
+    }
+}
+EOF
+systemctl restart nginx

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,58 +1,11 @@
+export DEBIAN_FRONTEND=noninteractive
+
 # Install build dependencies
+echo "deb http://ftp.de.debian.org/debian sid main" >> /etc/apt/sources.list
 apt update -y
 apt install git curl gcc make nginx -y
+printf "\n" | apt install gcc-10 -y
 
-# Download and install Rust toolchain
-curl https://sh.rustup.rs -sSf | sh -s -- -y
-source $HOME/.cargo/env
-
-# Git clone and build MeiliSearch for release on latest tag
-git clone https://github.com/meilisearch/MeiliSearch && cd MeiliSearch
-git checkout v0.8.4
-cargo build --release
-
-# Prepare systemd service for MeiliSearch
-mv target/release/meilisearch /usr/bin/
-cat << EOF >/etc/systemd/system/meilisearch.service
-[Unit]
-Description=MeiliSearch
-After=systend-user-sessions.service
-
-[Service]
-Type=simple
-ExecStart=/usr/bin/meilisearch
-
-[Install]
-WantedBy=default.target
-EOF
-
-# Start MeiliSearch service
-systemctl enable meilisearch
-systemctl start meilisearch
-
-# Setup firewalls and Nginx
-ufw allow 'Nginx Full'
-ufw allow 'OpenSSH'
-ufw --force enable
-
-# Set Nginx to proxy MeiliSearch
-cat << EOF > /etc/nginx/sites-enabled/default
-server {
-    listen 80 default_server;
-    listen [::]:80 default_server;
-
-    server_name _;
-
-    location / {
-        proxy_pass  http://127.0.0.1:7700;
-    }
-}
-EOF
-systemctl restart nginx
-
-# Clean up image using DO script
-curl https://raw.githubusercontent.com/digitalocean/marketplace-partners/master/scripts/cleanup.sh | bash
-rm /var/log/auth.log
-rm /var/log/kern.log
-rm /var/log/ufw.log
-curl https://raw.githubusercontent.com/digitalocean/marketplace-partners/master/scripts/img_check.sh | bash
+# Install MeiliSearch v0.10.0
+wget --directory-prefix=/etc/meilisearch/ https://github.com/meilisearch/MeiliSearch/releases/download/v0.10.0/meilisearch.deb
+apt install /etc/meilisearch/meilisearch.deb

--- a/deploy.sh
+++ b/deploy.sh
@@ -4,8 +4,27 @@ export DEBIAN_FRONTEND=noninteractive
 echo "deb http://ftp.de.debian.org/debian sid main" >> /etc/apt/sources.list
 apt update -y
 apt install git curl gcc make nginx -y
-printf "\n" | apt install gcc-10 -y
+apt install gcc-10 -y
 
 # Install MeiliSearch v0.10.0
 wget --directory-prefix=/etc/meilisearch/ https://github.com/meilisearch/MeiliSearch/releases/download/v0.10.0/meilisearch.deb
 apt install /etc/meilisearch/meilisearch.deb
+
+# Prepare systemd service for MeiliSearch
+mv target/release/meilisearch /usr/bin/
+cat << EOF >/etc/systemd/system/meilisearch.service
+[Unit]
+Description=MeiliSearch
+After=systend-user-sessions.service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/meilisearch
+
+[Install]
+WantedBy=default.target
+EOF
+
+# Start MeiliSearch service
+systemctl enable meilisearch
+systemctl start meilisearch

--- a/deploy.sh
+++ b/deploy.sh
@@ -28,3 +28,8 @@ EOF
 # Start MeiliSearch service
 systemctl enable meilisearch
 systemctl start meilisearch
+
+# Setup firewalls and Nginx
+ufw allow 'Nginx Full'
+ufw allow 'OpenSSH'
+ufw --force enable


### PR DESCRIPTION
Based on old deploy.sh script. Main modifications:

- Base on debian 10.3
- Update MeiliSearch version to v0.10.0
- Get MeiliSearch from .deb release, instead of compiling locally from github
- Default configuration from Nginx removed
