### PR TITLE
Fix: api key empty in service file

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -6,15 +6,15 @@ apt update -y
 apt upgrade -y
 apt install git curl ufw gcc make nginx certbot python-certbot-nginx qemu-utils gcc-10 -y
 
-# Install MeiliSearch v0.10.0
-wget --directory-prefix=/etc/meilisearch/ https://github.com/meilisearch/MeiliSearch/releases/download/v0.10.0/meilisearch.deb
+# Install MeiliSearch v0.10.1
+wget --directory-prefix=/etc/meilisearch/ https://github.com/meilisearch/MeiliSearch/releases/download/v0.10.1/meilisearch.deb
 apt install /etc/meilisearch/meilisearch.deb
 
 # Prepare systemd service for MeiliSearch
 cat << EOF >/etc/systemd/system/meilisearch.service
 [Unit]
 Description=MeiliSearch
-After=systend-user-sessions.service
+After=systemd-user-sessions.service
 
 [Service]
 Type=simple
@@ -51,7 +51,7 @@ mkdir -p /var/log/meilisearch
 mkdir -p /var/opt/meilisearch/scripts/first-login
 git clone https://github.com/meilisearch/meilisearch-digital-ocean.git /tmp/meili-tmp
 cd /tmp/meili-tmp
-git checkout v0.10.0
+git checkout v0.10.1
 chmod 755 /tmp/meili-tmp/scripts/per-instance/*
 chmod 755 /tmp/meili-tmp/scripts/first-login/*
 chmod 755 /tmp/meili-tmp/scripts/MOTD/*

--- a/scripts/first-login/000-set-meili-env.sh
+++ b/scripts/first-login/000-set-meili-env.sh
@@ -15,7 +15,7 @@ echo "\n\nThank you for using$BLUE MeiliSearch.$RESET\n\n"
 echo "This is the first login here, and we need to set some basic configuration first.\n"
 
 USE_API_KEY="false"
-MEILISEARCH_API_KEY=""
+MEILISEARCH_MASTER_KEY=""
 DOMAIN_NAME=""
 USE_SSL="false"
 USE_CERTBOT="false"
@@ -23,7 +23,7 @@ USE_CERTBOT="false"
 exit_with_message() {
 
     echo "export USE_API_KEY="$USE_API_KEY > /var/opt/meilisearch/env
-    echo "export MEILISEARCH_API_KEY="$MEILISEARCH_API_KEY >> /var/opt/meilisearch/env
+    echo "export MEILISEARCH_MASTER_KEY="$MEILISEARCH_MASTER_KEY >> /var/opt/meilisearch/env
     echo "export DOMAIN_NAME="$DOMAIN_NAME >> /var/opt/meilisearch/env
     echo "export USE_SSL="$USE_SSL >> /var/opt/meilisearch/env
     echo "export USE_CERTBOT="$USE_CERTBOT >> /var/opt/meilisearch/env
@@ -36,7 +36,7 @@ exit_with_message() {
 
 ask_master_key_setup() {
     while true; do
-        read -p "$(echo $BOLD$BLUE"Do you wish to setup a MEILI_API_KEY for your search engine [y/n]?  "$RESET)" yn
+        read -p "$(echo $BOLD$BLUE"Do you wish to setup a MEILI_MASTER_KEY for your search engine [y/n]?  "$RESET)" yn
         case $yn in
             [Yy]* ) set_master_key=true; break;;
             [Nn]* ) set_master_key=false; break;;
@@ -47,10 +47,10 @@ ask_master_key_setup() {
 
 generate_master_key() {
     while true; do
-        read -p "$(echo $BOLD$BLUE"Do you wish to specify you MEILI_API_KEY (otherwise it will be generated) [y/n]? "$RESET)" yn
+        read -p "$(echo $BOLD$BLUE"Do you wish to specify your MEILI_MASTER_KEY (otherwise it will be generated) [y/n]? "$RESET)" yn
         case $yn in
-            [Yy]* ) read -p "MEILI_API_KEY: " api_key; break;;
-            [Nn]* ) api_key=$(date +%s | sha256sum | base64 | head -c 32); echo "You MEILI_API_KEY is $api_key"; echo "You should keep it somewhere safe."; break;;
+            [Yy]* ) read -p "MEILI_MASTER_KEY: " api_key; break;;
+            [Nn]* ) api_key=$(date +%s | sha256sum | base64 | head -c 32); echo "You MEILI_MASTER_KEY is $api_key"; echo "You should keep it somewhere safe."; break;;
             * ) echo "Please answer yes or no.";;
         esac
     done
@@ -111,7 +111,7 @@ ask_master_key_setup
 if [ $set_master_key = true ]; then
     generate_master_key
     USE_API_KEY="true"
-    MEILISEARCH_API_KEY=$api_key
+    MEILISEARCH_MASTER_KEY=$api_key
 fi
 
 # Ask user if he wants to setup a domain name for MeiliSearch

--- a/scripts/first-login/001-setup-prod.sh
+++ b/scripts/first-login/001-setup-prod.sh
@@ -28,7 +28,7 @@ configure_master_key() {
     cat << EOF >/etc/systemd/system/meilisearch.service
 [Unit]
 Description=MeiliSearch
-After=systend-user-sessions.service
+After=systemd-user-sessions.service
 
 [Service]
 Type=simple

--- a/scripts/first-login/001-setup-prod.sh
+++ b/scripts/first-login/001-setup-prod.sh
@@ -33,7 +33,7 @@ After=systend-user-sessions.service
 [Service]
 Type=simple
 ExecStart=/usr/bin/meilisearch
-Environment="MEILI_MASTER_KEY=$MEILISEARCH_API_KEY"
+Environment="MEILI_MASTER_KEY=$MEILISEARCH_MASTER_KEY"
 
 [Install]
 WantedBy=default.target

--- a/scripts/first-login/001-setup-prod.sh
+++ b/scripts/first-login/001-setup-prod.sh
@@ -33,7 +33,7 @@ After=systend-user-sessions.service
 [Service]
 Type=simple
 ExecStart=/usr/bin/meilisearch
-Environment="MEILI_API_KEY=$api_key"
+Environment="MEILI_MASTER_KEY=$MEILISEARCH_API_KEY"
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
- After specifying a MASTER KEY in script, requests could be done without any authentication. The environment variable name used for the service file creation had a typo, leading to no env variable being set at all and MeiliSearch being launched with no MASTER KEY

- By mistake, deploy script wasn't updated, leading to a v0.10.0 installation.

- Fixed typos and renamed environment variable from `API_KEY` to `MASTER_KEY`

Closes #41 