### PR TITLE
Set environment to production only if master key

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -18,7 +18,7 @@ After=systemd-user-sessions.service
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/meilisearch --db-path /var/lib/meilisearch --env production
+ExecStart=/usr/bin/meilisearch --db-path /var/lib/meilisearch
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
Use dev environment by default, unless Master Key is set